### PR TITLE
Correction in "Create a Simulation Application"

### DIFF
--- a/doc_source/application-create-simjob.md
+++ b/doc_source/application-create-simjob.md
@@ -67,7 +67,7 @@ A simulation application contains all of the assets and logic needed to simulate
 1. Copy the simulation application source bundle to your Amazon S3 bucket\. The simulation application must be built for the `X86_64` platform\. The bundle might be `.tar` or `.tar.gz` extension\.
 
    ```
-   $ aws s3 cp simulation_app/bundle/robot_ws/bundle/output.tar.gz s3://MyApplicationSource/my-simulation-application.tar.gz
+   $ aws s3 cp simulation_ws/bundle/output.tar.gz s3://MyApplicationSource/my-simulation-application.tar.gz
    ```
 
 1. Create a simulation application in AWS RoboMaker\. 


### PR DESCRIPTION
The command to copy the contents of the simulation app from the bundle to the bucket is:
aws s3 cp simulation_app/bundle/robot_ws/bundle/output.tar.gz s3://myapplicationsource/my-simulation-application.tar.gz

I believe it should be:
aws s3 cp simulation_ws/bundle/output.tar.gz s3://myapplicationsource/my-simulation-application.tar.gz

So that one can copy not only the contents of robot_ws to the bucket, but also the contents of simulation_ws

(excuse me if I'm wrong, learning here)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
