### PR TITLE
Fix stated HelloWorld robot spin direction.

### DIFF
--- a/doc_source/gs-build-rundemo.md
+++ b/doc_source/gs-build-rundemo.md
@@ -16,7 +16,7 @@ Before you begin working with a robot application and simulation application cod
 
 1. In the **AWS RoboMaker gzclient** window, use the mouse or keyboard to zoom in on the TurtleBot\. For more information, see [Gazebo Keyboard Shortcuts](http://gazebosim.org/hotkeys)\.
 
-   It is spinning clockwise\. Gazebo is fully functional, so you can try out other features\. For example, if you want more light on the robot, choose the **sun** \(point light\) icon\. Then move the pointer around the robot to illuminate it\.
+   It is spinning counter-clockwise\. Gazebo is fully functional, so you can try out other features\. For example, if you want more light on the robot, choose the **sun** \(point light\) icon\. Then move the pointer around the robot to illuminate it\.
 
 1. When you are done, close Gazebo by closing the browser window\.
 


### PR DESCRIPTION
*Description of changes:*
The description of the direction that the Hello World robot spins was incorrect. It is important to state this information correctly because later in the "Getting Started" tutorial the user will is asked to make a change that should reverse the default spin direction. With inaccurate information the user will be confused about whether they've made the change successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
