### PR TITLE
Fix typos and formatting in filepath

### DIFF
--- a/doc_source/gs-build.md
+++ b/doc_source/gs-build.md
@@ -40,7 +40,7 @@ In this section, you use the AWS Cloud9 development environment to modify the ro
 
 1. In the **HelloWorld** AWS Cloud9 development environment, choose **Resources**, then choose **Download samples**, and then select **1\. Hello World**\.
 
-1. On the left, in the **Environment** tab, expand **HelloWorld**, **HelloWorld**, **robot\_ws**\. **src**, **hello\_world\_robot**, and then **nodes**\. Select the file **rotate** to load into the editor\.
+1. On the left, in the **Environment** tab, expand **HelloWorld**/**robot\_ws**/**src**/**hello\_world\_robot**/**nodes**\. Select the file **rotate** to load into the editor\.
 
 1. In the **rotate** tab, modify the code to make the robot turn clockwise by making the rate negative: `self.twist.angular.z = -0.1`\. Save the file by selecting **File** and then **Save**\. 
 


### PR DESCRIPTION
*Description of changes:*
In the file path describing where to find the "rotate" file, I removed an accidental duplicate of "HelloWorld" and fixed an errant period in the path name. I also changed from comma-delimited folder names to slash-delimited folder names which is more typical when referencing file paths. You can revert to comma delimited if you like, but the other changes are still relevant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
